### PR TITLE
Fix the `now` format

### DIFF
--- a/layouts/partials/head_includes.html
+++ b/layouts/partials/head_includes.html
@@ -33,9 +33,9 @@
     {{if .Site.Params.PrismTheme }}
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/themes/prism-{{ .Site.Params.PrismTheme }}.min.css">
     {{end}}
-    <link rel="stylesheet" type="text/css" href="/css/styles.css?{{ .Now.Unix }}">
+    <link rel="stylesheet" type="text/css" href="/css/styles.css?{{ now.Unix }}">
     {{range .Site.Params.ExtraCssFiles}}
-        <link rel="stylesheet" href="{{.}}?{{ .Now.Unix }}">
+        <link rel="stylesheet" href="{{.}}?{{ now.Unix }}">
     {{end}}
 
 {{ end }}


### PR DESCRIPTION
The syntax of the [now](https://gohugo.io/functions/now) function has changed since this theme was written. This PR updated the syntaxes and fixes build issues.

Fixes #3. See https://github.com/kritoke/darksimplicity/issues/4 for more info.